### PR TITLE
Add global summary to dashboard

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -12,6 +12,11 @@ export default {
     baseApiUrl: `${process.env.NEXT_PUBLIC_URL_API}/api`!,
 
     /**
+     * cUSD decimals to use in ui format
+     */
+    cUSDDecimals: 18,
+
+    /**
      * Base URL to api
      */
     chainExplorer: process.env.NEXT_PUBLIC_CHAIN_EXPLORER_URL!,

--- a/data/en.ts
+++ b/data/en.ts
@@ -32,11 +32,14 @@ export const en = {
             playstore: 'https://play.google.com/store/apps/details?id=com.impactmarket.mobile'
         },
         strings: {
+            beneficiary: 'Beneficiary',
             copyAddress: 'Copy address',
+            day: 'Day',
             donate: 'Donate',
             downloadApp: 'Download App',
             enterYourEmail: 'Enter your email...',
             invalidEmail: 'The email is not valid',
+            months: 'Months',
             required: 'A valid email is required',
             somethingWrong: 'Something went wrong. Try again later...',
             subscribe: 'Subscribe',
@@ -97,8 +100,39 @@ export const en = {
             }
         },
         globalDashboard: {
-            hero: {
-                heading: 'Lorem 2'
+            global: {
+                heading: 'Global dashboard',
+                text:
+                    'Explore the main indicators of impactMarket system both on inflow of funds and distribution of basic income to beneficiaries through their UBI community contracts.',
+                rows: [
+                    {
+                        heading: 'Inflow / Outflow',
+                        items: [
+                            { heading: 'Total Raised', helper: 'totalRaised' },
+                            { heading: 'Total Distributed', helper: 'totalDistributed' },
+                            { heading: '# Backers', helper: 'backers' },
+                            { heading: '# Beneficiaries', helper: 'beneficiaries' }
+                        ]
+                    },
+                    {
+                        heading: 'UBI Pulse',
+                        items: [
+                            { heading: 'Giving Rate per Backer', helper: 'ratePerBacker' },
+                            { heading: 'UBI Rate per Beneficiary', helper: 'ratePerBeneficiary' },
+                            { heading: 'Avg Cumulative UBI', helper: 'avgCumulativeUbi' },
+                            { heading: 'Avg UBI duration', helper: 'avgUbiDuration' }
+                        ]
+                    },
+                    {
+                        heading: "Economic beneficiaries' activity",
+                        items: [
+                            { heading: 'Total Volume', helper: 'totalVolume' },
+                            { heading: '# Transfers', helper: 'transfers' },
+                            { heading: 'Reach', helper: 'reach' },
+                            { heading: 'Spending Rate', helper: 'spendingRate' }
+                        ]
+                    }
+                ]
             }
         }
         /* eslint-enable sort-keys */

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@psoares/svg-list": "^1.1.6",
-    "@types/react-scroll": "^1.8.2",
     "axios": "^0.21.1",
+    "bignumber.js": "^9.0.1",
     "html-react-parser": "^1.2.4",
     "lodash": "^4.17.21",
     "next": "latest",
@@ -30,11 +30,13 @@
     "type-fest": "^0.21.3"
   },
   "devDependencies": {
+    "@types/bignumber.js": "^5.0.0",
     "@types/lodash": "^4.14.168",
     "@types/node": "^14.14.31",
     "@types/react": "^17.0.2",
     "@types/react-copy-to-clipboard": "^5.0.0",
     "@types/react-dom": "^17.0.1",
+    "@types/react-scroll": "^1.8.2",
     "@types/styled-components": "^5.1.7",
     "babel-plugin-styled-components": "^1.8.0",
     "eslint": "^7.21.0",

--- a/src/apis/dashboard.ts
+++ b/src/apis/dashboard.ts
@@ -1,0 +1,82 @@
+import { IGlobalDashboard } from './types';
+import { currencyValue } from '../helpers/currencyValues';
+import { humanifyNumber } from '../helpers/humanifyNumber';
+import { numericalValue } from '../helpers/numericalValue';
+import BigNumber from 'bignumber.js';
+
+export const dashboard: { [key: string]: Function } = {
+    getAvgCumulativeUbi: (data: IGlobalDashboard, getString: Function) => ({
+        prefix: '~',
+        suffix: `/${getString('beneficiary')}`,
+        value: currencyValue(humanifyNumber(data?.monthly[0]?.avgComulativeUbi), false)
+    }),
+
+    getAvgUbiDuration: (data: IGlobalDashboard, getString: Function) => ({
+        prefix: '~',
+        suffix: `${getString('months')} / ${getString('beneficiary')}`,
+        value: numericalValue(data?.monthly[0]?.avgUbiDuration.toString(), false)
+    }),
+
+    getBackers: (data: IGlobalDashboard) => ({
+        value: numericalValue(data?.totalBackers?.toString())
+    }),
+
+    getBeneficiaries: (data: IGlobalDashboard) => ({
+        value: numericalValue((data?.monthly[0]?.totalBeneficiaries + data?.today?.totalBeneficiaries).toString())
+    }),
+
+    getHelper: (helper: string, data: IGlobalDashboard, getString: Function): Function => {
+        const method: string = `get${`${helper.charAt(0).toUpperCase()}${helper.slice(1)}`}`;
+
+        const helperFunction: any = dashboard[method];
+
+        if (!helperFunction || !data) {
+            return () => {};
+        }
+
+        return helperFunction(data, getString);
+    },
+
+    getRatePerBacker: (data: IGlobalDashboard, getString: Function) => ({
+        prefix: '~',
+        suffix: `/${getString('day')}`,
+        value: currencyValue(data?.monthly[0]?.givingRate.toString())
+    }),
+
+    getRatePerBeneficiary: (data: IGlobalDashboard, getString: Function) => ({
+        prefix: '~',
+        suffix: `/${getString('day')}`,
+        value: currencyValue(data?.monthly[0]?.ubiRate.toString())
+    }),
+
+    getReach: (data: IGlobalDashboard) => ({
+        value: numericalValue(data?.monthly[0]?.totalReach.toString())
+    }),
+
+    getSpendingRate: () => ({
+        value: '- -'
+    }),
+
+    getTotalDistributed: (data: IGlobalDashboard) => ({
+        suffix: 'cUSD',
+        value: currencyValue(
+            humanifyNumber(new BigNumber(data?.monthly[0]?.totalDistributed).plus(data?.today?.totalClaimed).toString())
+        )
+    }),
+
+    getTotalRaised: (data: IGlobalDashboard) => ({
+        suffix: 'cUsd',
+        value: currencyValue(
+            humanifyNumber(new BigNumber(data?.monthly[0]?.totalRaised).plus(data?.today?.totalRaised).toString())
+        )
+    }),
+
+    getTotalVolume: (data: IGlobalDashboard) => ({
+        suffix: 'cUsd',
+        value: currencyValue(humanifyNumber(data?.monthly[0]?.totalVolume))
+    }),
+
+    getTransfers: (data: IGlobalDashboard) => ({
+        value: numericalValue(data?.monthly[0]?.totalTransactions.toString())
+    })
+};

--- a/src/components/DashboardNumericContent/DashboardNumericContent.tsx
+++ b/src/components/DashboardNumericContent/DashboardNumericContent.tsx
@@ -1,0 +1,27 @@
+import { Div, Heading, Text } from '../../theme/components';
+import { GeneratedPropsTypes } from '../../theme/Types';
+import React from 'react';
+
+type DashboardNumericContentProps = { content: any } & GeneratedPropsTypes;
+
+export const DashboardNumericContent = (props: DashboardNumericContentProps) => {
+    const { content, ...forwardProps } = props;
+
+    if (!content) {
+        return null;
+    }
+
+    const { prefix, value, suffix } = props.content;
+
+    return (
+        <Div sAlignItems="baseline" {...forwardProps}>
+            {!!prefix && <Heading h3>{prefix}</Heading>}
+            <Heading h3>{value || '- -'}</Heading>
+            {!!suffix && (
+                <Text XXSmall ml={0.25}>
+                    {suffix}
+                </Text>
+            )}
+        </Div>
+    );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Cta/Cta';
+export * from './DashboardNumericContent/DashboardNumericContent';
 export * from './DonateButton/DonateButton';
 export * from './Footer/Footer';
 export * from './Header/Header';

--- a/src/helpers/claimFrequencytoText.ts
+++ b/src/helpers/claimFrequencytoText.ts
@@ -1,0 +1,15 @@
+import { BigNumber } from 'bignumber.js';
+
+export const claimFrequencyToText = (frequency: BigNumber | string): string => {
+    const f = new BigNumber(frequency);
+
+    if (f.eq(86400)) {
+        return 'day';
+    }
+
+    if (f.eq(604800)) {
+        return 'week';
+    }
+
+    return 'unknown';
+};

--- a/src/helpers/currencyValues.ts
+++ b/src/helpers/currencyValues.ts
@@ -1,0 +1,5 @@
+import { BigNumber } from 'bignumber.js';
+import { numericalValue } from './numericalValue';
+
+export const currencyValue = (inputNumber: BigNumber | string, decimals: boolean = true) =>
+    `$${numericalValue(inputNumber, decimals)}`;

--- a/src/helpers/humanifyNumber.ts
+++ b/src/helpers/humanifyNumber.ts
@@ -1,0 +1,8 @@
+import { BigNumber } from 'bignumber.js';
+import config from '../../config';
+
+export const humanifyNumber = (inputNumber: BigNumber | string): string => {
+    const decimals = new BigNumber(10).pow(config.cUSDDecimals);
+
+    return new BigNumber(inputNumber).div(decimals).decimalPlaces(2, 1).toString();
+};

--- a/src/helpers/numericalValue.ts
+++ b/src/helpers/numericalValue.ts
@@ -1,0 +1,4 @@
+import { BigNumber } from 'bignumber.js';
+
+export const numericalValue = (inputNumber: BigNumber | string, decimals: boolean = true) =>
+    Number(inputNumber).toLocaleString('en', { maximumFractionDigits: decimals ? 2 : 0 });

--- a/src/page-components/GlobalDashboard/Global/Global.tsx
+++ b/src/page-components/GlobalDashboard/Global/Global.tsx
@@ -1,0 +1,65 @@
+import { Col, DashboardCard, Grid, Heading, Row, Section, Text } from '../../../theme/components';
+import { DashboardNumericContent } from '../../../components';
+import { IGlobalDashboard } from '../../../apis/types';
+import { dashboard as dashboardHelpers } from '../../../apis/dashboard';
+import { useData } from '../../../components/DataProvider/DataProvider';
+import React from 'react';
+
+type GlobalProps = {
+    data?: IGlobalDashboard;
+    heading?: string;
+    rows?: {
+        heading?: string;
+        items?: {
+            heading?: string;
+            helper?: string;
+        }[];
+    }[];
+    text?: string;
+};
+
+export const Global = (props: GlobalProps) => {
+    const { data, heading, rows, text } = props;
+    const { getString } = useData();
+
+    return (
+        <Section pt={2} sBackground="backgroundLight">
+            <Grid>
+                <Row>
+                    <Col xs={12}>
+                        <Heading h2>{heading}</Heading>
+                        <Text mt={0.5} small>
+                            {text}
+                        </Text>
+                    </Col>
+                </Row>
+                {rows &&
+                    rows.map(({ heading, items: colItems }, index) => (
+                        <React.Fragment key={index}>
+                            <Row mb={0.5} mt={2}>
+                                <Col xs={12}>
+                                    <Heading h6>{heading}</Heading>
+                                </Col>
+                            </Row>
+                            <Row vGutter={1.25}>
+                                {colItems &&
+                                    colItems.map(({ heading: colHeading, helper }, colIndex) => (
+                                        <Col key={colIndex} md={3} sm={6} xs={12}>
+                                            <DashboardCard>
+                                                <Text body ellipsis textSecondary>
+                                                    {colHeading}
+                                                </Text>
+                                                <DashboardNumericContent
+                                                    content={dashboardHelpers.getHelper(helper, data, getString)}
+                                                    mt="auto"
+                                                />
+                                            </DashboardCard>
+                                        </Col>
+                                    ))}
+                            </Row>
+                        </React.Fragment>
+                    ))}
+            </Grid>
+        </Section>
+    );
+};

--- a/src/page-components/GlobalDashboard/GlobalDashboard.tsx
+++ b/src/page-components/GlobalDashboard/GlobalDashboard.tsx
@@ -1,0 +1,22 @@
+import { Global } from './Global/Global';
+import { IGlobalDashboard } from '../../apis/types';
+import { useData } from '../../components/DataProvider/DataProvider';
+import React from 'react';
+
+type GlobalDashboardProps = {
+    data: IGlobalDashboard;
+    page: string;
+};
+
+export const GlobalDashboard = (props: GlobalDashboardProps) => {
+    const { page } = useData();
+    const { data } = props;
+
+    const global = page?.global;
+
+    return (
+        <>
+            <Global data={data} {...global} />
+        </>
+    );
+};

--- a/src/page-components/index.ts
+++ b/src/page-components/index.ts
@@ -1,1 +1,2 @@
+export * from './GlobalDashboard/GlobalDashboard';
 export * from './Homepage/Homepage';

--- a/src/pages/global-dashboard.tsx
+++ b/src/pages/global-dashboard.tsx
@@ -1,31 +1,5 @@
-import { Col, Grid, Heading, Row } from '../theme/components';
-import { IGlobalDashboard } from '../apis/types';
-import { useData } from '../components/DataProvider/DataProvider';
+import { GlobalDashboard } from '../page-components';
 import Api from '../apis/api';
-import React from 'react';
-
-type GlobalDashboardProps = {
-    data: IGlobalDashboard;
-    page: string;
-};
-
-const GlobalDashboard = (props: GlobalDashboardProps) => {
-    const { page } = useData();
-
-    console.log(props);
-
-    return (
-        <Grid pt={{ md: 5, xs: 3 }}>
-            <Row>
-                <Col xs={12}>
-                    <Heading h1 semibold>
-                        {page?.hero?.heading}
-                    </Heading>
-                </Col>
-            </Row>
-        </Grid>
-    );
-};
 
 export const getServerSideProps = async () => {
     const data = await Api.getGlobalValues();

--- a/src/theme/Types/index.ts
+++ b/src/theme/Types/index.ts
@@ -7,7 +7,7 @@ const spaceNames = ['mb', 'ml', 'mr', 'mt', 'pb', 'pl', 'pr', 'pt'] as const;
  * Helper Types
  */
 export type BoolProps<T extends Object> = Partial<Record<keyof T, boolean>>;
-type MqProp<T> = Partial<Record<typeof breakpoints[number], T>> | T;
+export type MqProp<T> = Partial<Record<typeof breakpoints[number], T>> | T;
 
 /**
  * GeneratedPropsTypes

--- a/src/theme/components/Chip/Chip.tsx
+++ b/src/theme/components/Chip/Chip.tsx
@@ -13,7 +13,7 @@ export const Chip = styled.div<ChipProps>`
     align-items: center;
     background-color: ${colors.backgroundSecondary};
     border-radius: 22px;
-    color: ${colors.backgroundSecondary};
+    color: ${colors.textPrimary};
     display: inline-flex;
     font-family: ${fonts.families.inter};
     font-weight: ${fonts.weights.medium};

--- a/src/theme/components/DashboardCard/DashboardCard.tsx
+++ b/src/theme/components/DashboardCard/DashboardCard.tsx
@@ -1,0 +1,17 @@
+import { GeneratedPropsTypes } from '../../Types';
+import { colors } from '../../variables/colors';
+import { generateProps } from 'styled-gen';
+import styled from 'styled-components';
+
+export const DashboardCard = styled.div<GeneratedPropsTypes>`
+    background-color: ${colors.white};
+    border-radius: 0.5rem;
+    border: 1px solid ${colors.backgroundSecondary};
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    padding: 1rem 1.375rem;
+
+    ${generateProps}
+`;

--- a/src/theme/components/GlobalStyle/GlobalStyle.tsx
+++ b/src/theme/components/GlobalStyle/GlobalStyle.tsx
@@ -19,7 +19,7 @@ export const GlobalStyle = createGlobalStyle`
         box-sizing: border-box;
         color: ${colors.textPrimary};
         font-family: ${fonts.families.inter};
-        font-size: 1.125rem;
+        font-size: 1rem;
         line-height: 1.5;
         overflow-x: hidden;
         overflow-y: scroll;

--- a/src/theme/components/Grid/Grid.tsx
+++ b/src/theme/components/Grid/Grid.tsx
@@ -1,16 +1,68 @@
 import * as FlexboxGrid from 'react-styled-flexboxgrid';
-import { GeneratedPropsTypes } from '../../Types';
-import { generateProps } from 'styled-gen';
-import styled from 'styled-components';
+import { GeneratedPropsTypes, MqProp } from '../../Types';
+import { breakpoints } from '../../variables/breakpoints';
+import { generateProps, mq } from 'styled-gen';
+import styled, { css } from 'styled-components';
+
+// eslint-disable-next-line sort-keys
+const bpMap: { [key: string]: string } = { xs: 'phone', sm: 'tablet', md: 'tabletLandscape', lg: 'desktop' };
+
+const applyPaddedStyle = (value: any, bp?: string) => {
+    const styleValue = Number.isNaN(value) ? value : `${value / 2}rem`;
+    const style = css`
+        margin-bottom: -${styleValue};
+        margin-top: -${styleValue};
+
+        & > * {
+            padding-bottom: ${styleValue};
+            padding-top: ${styleValue};
+        }
+    `;
+
+    if (!bp || !bpMap[bp] || bp === 'xs') {
+        return style;
+    }
+
+    return mq.from(bp, style);
+};
+
+const padded = (props: any) => {
+    const vGutter = props?.vGutter;
+    const defaultValue = 1;
+
+    if (!vGutter || (typeof vGutter === 'object' && !Object.keys(vGutter)?.length)) {
+        return;
+    }
+
+    if (typeof vGutter === 'object') {
+        return Object.keys(bpMap).map((bp: string) =>
+            vGutter[bp] !== undefined ? applyPaddedStyle(vGutter[bp], bp) : ''
+        );
+    }
+
+    return applyPaddedStyle(vGutter || defaultValue);
+};
 
 export const Col = styled(FlexboxGrid.Col)<GeneratedPropsTypes>`
     ${generateProps};
 `;
 
 export const Grid = styled(FlexboxGrid.Grid)<GeneratedPropsTypes>`
+    ${mq.upTo(
+        `${breakpoints.lg}em`,
+        css`
+            width: 100%;
+        `
+    )}
+
     ${generateProps};
 `;
 
-export const Row = styled(FlexboxGrid.Row)<GeneratedPropsTypes>`
+type RowProps = {
+    vGutter?: MqProp<number | string>;
+};
+
+export const Row = styled(FlexboxGrid.Row)<GeneratedPropsTypes & RowProps>`
+    ${padded};
     ${generateProps};
 `;

--- a/src/theme/components/Section/Section.tsx
+++ b/src/theme/components/Section/Section.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 
 export const Section = styled.section<GeneratedPropsTypes>`
     display: block;
+    margin-left: auto;
+    margin-right: auto;
     overflow: hidden;
 
     ${generateProps}

--- a/src/theme/components/Typography/Typography.tsx
+++ b/src/theme/components/Typography/Typography.tsx
@@ -30,28 +30,38 @@ const setSizeVariations = (sizeVariations: any) =>
         {}
     );
 
-const headingSizeVariations = setSizeVariations(headingSizes);
+const miscVariations = {
+    ellipsis: css`
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    `
+};
 
-const BodySizeVariations = setSizeVariations(bodySizes);
+const bodySizeVariations = setSizeVariations(bodySizes);
+const headingSizeVariations = setSizeVariations(headingSizes);
 
 type FontBodySizeVariations = BoolProps<typeof bodySizes>;
 type FontHeadingSizeVariations = BoolProps<typeof headingSizes>;
+type MiscVariations = BoolProps<typeof miscVariations>;
 
 export const Heading = styled.h1.attrs((props: object) => ({
     as: getTag(props, { defaultTag: 'h1' })
-}))<FontHeadingSizeVariations & GeneratedPropsTypes>`
+}))<FontHeadingSizeVariations & GeneratedPropsTypes & MiscVariations>`
     font-weight: ${fonts.weights.extrabold};
     font-family: ${fonts.families.manrope};
 
     ${variations(headingSizeVariations)};
+    ${variations(miscVariations)};
     ${generateProps};
 `;
 
 export const Text = styled.p.attrs((props: object) => ({
     as: getTag(props, { defaultTag: 'p' })
-}))<FontBodySizeVariations & GeneratedPropsTypes>`
+}))<FontBodySizeVariations & GeneratedPropsTypes & MiscVariations>`
     font-family: ${fonts.families.inter};
 
-    ${variations(BodySizeVariations)};
+    ${variations(bodySizeVariations)};
+    ${variations(miscVariations)};
     ${generateProps};
 `;

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -3,6 +3,7 @@ export * from './Button/Button';
 export * from './Chip/Chip';
 export * from './Content/Content';
 export * from './Currency/Currency';
+export * from './DashboardCard/DashboardCard';
 export * from './Div/Div';
 export * from './GlobalStyle/GlobalStyle';
 export * from './Grid/Grid';

--- a/src/theme/variables/breakpoints.ts
+++ b/src/theme/variables/breakpoints.ts
@@ -1,0 +1,3 @@
+export const breakpoints = {
+    lg: 80
+};

--- a/src/theme/variables/flexAlignments.ts
+++ b/src/theme/variables/flexAlignments.ts
@@ -9,6 +9,7 @@ export const justifyContentAlignments = {
 };
 
 export const alignItemsAligments = {
+    baseline: 'baseline',
     center: 'center',
     end: 'flex-end',
     start: 'flex-start',

--- a/src/theme/variables/flexboxgrid.ts
+++ b/src/theme/variables/flexboxgrid.ts
@@ -1,9 +1,11 @@
+import { breakpoints } from './breakpoints';
 import { container } from './container';
 
 export const flexboxgrid = {
+    breakpoints,
     container,
     gridSize: 12,
-    gutterWidth: 2,
+    gutterWidth: 1.25,
     mediaQuery: 'only screen',
     outerMargin: 2
 };

--- a/src/theme/variables/fonts.ts
+++ b/src/theme/variables/fonts.ts
@@ -22,7 +22,8 @@ export const bodySizes = {
 
     body: [16, 32],
     small: [14, 22],
-    XXSmall: [12, 16, 0],
+    XSmall: [12, 16],
+    XXSmall: [10, 19],
 
     label1: [20, 30],
     label2: [14, 20],

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,13 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.1.1.tgz#3348564048e7a2d7398c935d466c0414ebb6a669"
   integrity sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==
 
+"@types/bignumber.js@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bignumber.js/-/bignumber.js-5.0.0.tgz#d9f1a378509f3010a3255e9cc822ad0eeb4ab969"
+  integrity sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==
+  dependencies:
+    bignumber.js "*"
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -788,6 +795,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@*, bignumber.js@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
 binary-extensions@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
This PR adds the global summary to the global-dashboard page:
<img width="1273" alt="Screenshot 2021-03-27 at 23 30 09" src="https://user-images.githubusercontent.com/7081017/112737731-8cf7b180-8f54-11eb-96d3-ccdfd18241d4.png">
