### PR TITLE
Add monthly fundraising

### DIFF
--- a/data/en.ts
+++ b/data/en.ts
@@ -41,10 +41,13 @@ export const en = {
             donate: 'Donate',
             downloadApp: 'Download App',
             enterYourEmail: 'Enter your email...',
+            fundingRateOn: '{{value}}% funding rate on {{date}}',
             invalidEmail: 'The email is not valid',
             many: 'many',
+            monthlyActiveBackers: '{{value}} monthly active backers on {{date}}',
             months: 'Months',
             newBeneficiariesOn: '{{ value }} new beneficiaries on {{ date }}',
+            raisedOn: '${{value}} raised on {{date}}',
             required: 'A valid email is required',
             rowsPerPage: 'Rows per page',
             somethingWrong: 'Something went wrong. Try again later...',
@@ -185,8 +188,19 @@ export const en = {
                     { heading: '# Claims', helper: 'claims' },
                     { heading: 'New Beneficiaries', helper: 'newBeneficiaries' }
                 ]
+            },
+            fundraising: {
+                heading: 'Monthly Fundraising',
+                text:
+                    'Anyone can back those communities by sending $cUSD (Celo Dollar) directly to their contracts. This measures global monthly inflow, and its rate vs distribution.',
+                charts: [
+                    { heading: 'Raised', helper: 'raised' },
+                    { heading: '# Backers', helper: 'backers' },
+                    { heading: 'Funding Rate', helper: 'fundingRate' }
+                ]
             }
         }
         /* eslint-enable sort-keys */
     }
 };
+

--- a/src/apis/fundraising.ts
+++ b/src/apis/fundraising.ts
@@ -1,0 +1,73 @@
+import { IGlobalDashboard } from './types';
+import { bracked } from '../helpers/bracked';
+import { currencyValue } from '../helpers/currencyValues';
+import { humanifyNumber } from '../helpers/humanifyNumber';
+import { numericalValue } from '../helpers/numericalValue';
+import BigNumber from 'bignumber.js';
+import moment from 'moment';
+
+const getTooltip = (tooltip: string, payload: any, label: any) => {
+    // eslint-disable-next-line radix
+    const date = moment(parseInt(label!)).format('MMMM Do');
+    const value = payload[0]?.value || '--';
+
+    return bracked(tooltip, { date, value });
+};
+
+export const fundraising: { [key: string]: Function } = {
+    backers: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly
+                    .map(({ backers, date }) => ({ name: new Date(date).getTime(), uv: backers }))
+                    .reverse(),
+                tooltip: (payload: any, label: any): string =>
+                    getTooltip(getString('monthlyActiveBackers'), payload, label)
+            },
+            growth: data.growth.backers,
+            numeric: {
+                value: numericalValue(data.monthly[0].backers.toString())
+            }
+        };
+    },
+    fundingRate: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly
+                    .map(({ date, fundingRate }) => ({ name: new Date(date).getTime(), uv: fundingRate }))
+                    .reverse(),
+                tooltip: (payload: any, label: any): string => getTooltip(getString('fundingRateOn'), payload, label)
+            },
+            growth: data.growth.fundingRate,
+            numeric: {
+                suffix: '%',
+                value: data.monthly[0].fundingRate.toString()
+            }
+        };
+    },
+    raised: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly
+                    .map(({ date, raised }) => ({
+                        name: new Date(date).getTime(),
+                        uv: parseFloat(humanifyNumber(raised))
+                    }))
+                    .reverse(),
+                tooltip: (payload: any, label: any): string => getTooltip(getString('raisedOn'), payload, label),
+                type: 'bar'
+            },
+            growth: data.growth.raised,
+            numeric: {
+                suffix: 'cUsd',
+                value: currencyValue(
+                    humanifyNumber(
+                        data.monthly
+                            .reduce((results, { raised }) => results.plus(raised), new BigNumber('0'))
+                            .toString()
+                    )
+                )
+            }
+        };
+    }
+};

--- a/src/components/DashboardChartGroup/DashboardChartGroup.tsx
+++ b/src/components/DashboardChartGroup/DashboardChartGroup.tsx
@@ -1,6 +1,7 @@
 import { Col, DashboardCard, Div, Grid, Heading, Icon, Row, Section, Text } from '../../theme/components';
 import { DashboardChart } from '../DashboardChart/DashboardChart';
 import { DashboardNumericContent } from '../DashboardNumericContent/DashboardNumericContent';
+import { GeneratedPropsTypes } from '../../theme/Types';
 import { useData } from '../DataProvider/DataProvider';
 import React from 'react';
 
@@ -15,16 +16,16 @@ type DashboardChartGroupProps = {
     text?: string;
 };
 
-export const DashboardChartGroup = (props: DashboardChartGroupProps) => {
-    const { charts, heading, text } = props;
+export const DashboardChartGroup = (props: DashboardChartGroupProps & GeneratedPropsTypes) => {
+    const { charts, heading, text, ...forwardProps } = props;
     const { getString } = useData();
 
     return (
-        <Section pt={{ xs: 2 }} sBackground="backgroundLight">
+        <Section pt={{ sm: 4, xs: 2 }} sBackground="backgroundLight" {...forwardProps}>
             <Grid>
                 <Row>
                     <Col xs={12}>
-                        <Heading h2>{heading}</Heading>
+                        <Heading h3>{heading}</Heading>
                         <Text mt={0.5} small>
                             {text}
                         </Text>

--- a/src/components/Footer/Footer.style.ts
+++ b/src/components/Footer/Footer.style.ts
@@ -10,7 +10,7 @@ export const FooterLogo = styled(Icon).attrs({ icon: 'im' })`
 `;
 
 export const FooterWrapper = styled.div`
-    background-color: ${colors.backgroundLight};
+    background-color: ${colors.white};
     margin-top: auto;
     padding: 3.75rem 0 2.625rem;
     width: 100%;

--- a/src/page-components/GlobalDashboard/Communities/Communities.tsx
+++ b/src/page-components/GlobalDashboard/Communities/Communities.tsx
@@ -98,7 +98,7 @@ export const Communities = (props: CommunitiesProps) => {
             <Grid>
                 <Row>
                     <Col xs={12}>
-                        <Heading h2>
+                        <Heading h3>
                             {heading.replace(
                                 '{{ communitiesCount }}',
                                 `${communities?.length || getString('many') || ''}`

--- a/src/page-components/GlobalDashboard/Fundraising/Fundraising.tsx
+++ b/src/page-components/GlobalDashboard/Fundraising/Fundraising.tsx
@@ -1,0 +1,26 @@
+import { DashboardChartGroup } from '../../../components';
+import { IGlobalDashboard } from '../../../apis/types';
+import { fundraising } from '../../../apis/fundraising';
+import { useData } from '../../../components/DataProvider/DataProvider';
+import React from 'react';
+
+type FundraisingProps = {
+    data?: IGlobalDashboard;
+    charts: any[];
+};
+
+export const Fundraising = (props: FundraisingProps) => {
+    const { data, charts, ...forwardProps } = props;
+    const { getString } = useData();
+
+    const chartsConfig = charts.map(({ heading, helper }) => {
+        const helperData = fundraising[helper] ? fundraising[helper](data, getString) : {};
+
+        return {
+            ...helperData,
+            heading
+        };
+    });
+
+    return <DashboardChartGroup charts={chartsConfig} {...forwardProps} />;
+};

--- a/src/page-components/GlobalDashboard/GlobalDashboard.tsx
+++ b/src/page-components/GlobalDashboard/GlobalDashboard.tsx
@@ -1,5 +1,6 @@
 import { Communities } from './Communities/Communities';
 import { Distribution } from './Distribution/Distribution';
+import { Fundraising } from './Fundraising/Fundraising';
 import { Global } from './Global/Global';
 import { HealingMap } from './HealingMap/HealingMap';
 import { IGlobalDashboard } from '../../apis/types';
@@ -19,6 +20,7 @@ export const GlobalDashboard = (props: GlobalDashboardProps) => {
     const healingMap = page?.healingMap;
     const communities = page?.communities;
     const distribution = page?.distribution;
+    const fundraising = page?.fundraising;
 
     return (
         <>
@@ -26,6 +28,7 @@ export const GlobalDashboard = (props: GlobalDashboardProps) => {
             <HealingMap {...healingMap} />
             <Communities data={data} {...communities} />
             <Distribution data={data} {...distribution} />
+            <Fundraising data={data} {...fundraising} />
         </>
     );
 };

--- a/src/page-components/GlobalDashboard/HealingMap/HealingMap.tsx
+++ b/src/page-components/GlobalDashboard/HealingMap/HealingMap.tsx
@@ -28,7 +28,7 @@ export const HealingMap = (props: HealingMapProps) => {
             <Grid>
                 <Row>
                     <Col xs={12}>
-                        <Heading h2>{heading}</Heading>
+                        <Heading h3>{heading}</Heading>
                         <Text mt={0.5} small>
                             {text}
                         </Text>


### PR DESCRIPTION
This PR adds the monthly fundraising chart group to global dashboard page:
<img width="1353" alt="Screenshot 2021-04-01 at 15 23 14" src="https://user-images.githubusercontent.com/7081017/113317109-f38b1f80-9306-11eb-8eae-3ffa9fcb5496.png">
<img width="372" alt="Screenshot 2021-04-01 at 15 23 31" src="https://user-images.githubusercontent.com/7081017/113317123-f6861000-9306-11eb-9422-a73974694c43.png">
