### PR TITLE
Add economic charts

### DIFF
--- a/data/en.ts
+++ b/data/en.ts
@@ -32,6 +32,7 @@ export const en = {
             playstore: 'https://play.google.com/store/apps/details?id=com.impactmarket.mobile'
         },
         strings: {
+            addressReachedOn: '{{ value }} addresses reached on {{ date }}',
             beneficiary: 'Beneficiary',
             claimedOn: '${{ value }} claimed on {{ date }}',
             claimsOn: '{{ value }} claims on {{ date }}',
@@ -44,10 +45,10 @@ export const en = {
             fundingRateOn: '{{value}}% funding rate on {{date}}',
             invalidEmail: 'The email is not valid',
             many: 'many',
-            monthlyActiveBackers: '{{value}} monthly active backers on {{date}}',
+            monthlyActiveBackers: '{{ value }} monthly active backers on {{ date} }',
             months: 'Months',
             newBeneficiariesOn: '{{ value }} new beneficiaries on {{ date }}',
-            raisedOn: '${{value}} raised on {{date}}',
+            raisedOn: '${{ value }} raised on {{ date }}',
             required: 'A valid email is required',
             rowsPerPage: 'Rows per page',
             somethingWrong: 'Something went wrong. Try again later...',
@@ -55,6 +56,8 @@ export const en = {
             subscribeSuccess: 'Thanks for subscribing!',
             subscribingNote:
                 'By subscribing you will get updates about our progress, new features and impact measurement.',
+            transactedOn: '${{ value }} transacted on {{ date }}',
+            transactionsOn: '{{ value }} transactions on {{ date }}',
             vsPrevious30Days: 'vs previous 30 days',
             wrongEmail: 'Wrong email'
         },
@@ -198,9 +201,18 @@ export const en = {
                     { heading: '# Backers', helper: 'backers' },
                     { heading: 'Funding Rate', helper: 'fundingRate' }
                 ]
+            },
+            economic: {
+                heading: 'Monthly Economic Development',
+                text:
+                    "Main indicators on beneficiaries' direct financial activity including volume transacted last month, number of transactions, and how many people they have reached/transacted with.",
+                charts: [
+                    { heading: 'Volume', helper: 'volume' },
+                    { heading: '# Transfers', helper: 'transfers' },
+                    { heading: 'Reach', helper: 'reach' }
+                ]
             }
         }
         /* eslint-enable sort-keys */
     }
 };
-

--- a/src/apis/economic.ts
+++ b/src/apis/economic.ts
@@ -1,0 +1,69 @@
+import { IGlobalDashboard } from './types';
+import { bracked } from '../helpers/bracked';
+import { currencyValue } from '../helpers/currencyValues';
+import { humanifyNumber } from '../helpers/humanifyNumber';
+import { numericalValue } from '../helpers/numericalValue';
+import BigNumber from 'bignumber.js';
+import moment from 'moment';
+
+const getTooltip = (tooltip: string, payload: any, label: any) => {
+    // eslint-disable-next-line radix
+    const date = moment(parseInt(label!)).format('MMMM Do');
+    const value = payload[0]?.value || '--';
+
+    return bracked(tooltip, { date, value });
+};
+
+export const economic: { [key: string]: Function } = {
+    reach: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly.map(({ date, reach }) => ({ name: new Date(date).getTime(), uv: reach })).reverse(),
+                tooltip: (payload: any, label: any): string => getTooltip(getString('addressReachedOn'), payload, label)
+            },
+            growth: data.growth.reach,
+            numeric: {
+                value: numericalValue(data.reachedLastMonth.reach.toString())
+            }
+        };
+    },
+    transfers: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly
+                    .map(({ date, transactions }) => ({ name: new Date(date).getTime(), uv: transactions }))
+                    .reverse(),
+                tooltip: (payload: any, label: any): string => getTooltip(getString('transactionsOn'), payload, label)
+            },
+            growth: data.growth.transactions,
+            numeric: {
+                value: numericalValue(
+                    data.monthly.reduce((result, { transactions }) => result + transactions, 0).toString()
+                )
+            }
+        };
+    },
+    volume: (data: IGlobalDashboard, getString: Function) => {
+        return {
+            chart: {
+                data: data.monthly
+                    .map(({ date, volume }) => ({
+                        name: new Date(date).getTime(),
+                        uv: parseFloat(humanifyNumber(volume))
+                    }))
+                    .reverse(),
+                tooltip: (payload: any, label: any): string => getTooltip(getString('transactedOn'), payload, label),
+                type: 'bar'
+            },
+            growth: data.growth.volume,
+            numeric: {
+                suffix: 'cUsd',
+                value: currencyValue(
+                    humanifyNumber(
+                        data.monthly.reduce((result, { volume }) => result.plus(volume), new BigNumber('0')).toString()
+                    )
+                )
+            }
+        };
+    }
+};

--- a/src/page-components/GlobalDashboard/Economic/Economic.tsx
+++ b/src/page-components/GlobalDashboard/Economic/Economic.tsx
@@ -1,0 +1,26 @@
+import { DashboardChartGroup } from '../../../components';
+import { IGlobalDashboard } from '../../../apis/types';
+import { economic } from '../../../apis/economic';
+import { useData } from '../../../components/DataProvider/DataProvider';
+import React from 'react';
+
+type EconomicProps = {
+    data?: IGlobalDashboard;
+    charts: any[];
+};
+
+export const Economic = (props: EconomicProps) => {
+    const { data, charts, ...forwardProps } = props;
+    const { getString } = useData();
+
+    const chartsConfig = charts.map(({ heading, helper }) => {
+        const helperData = economic[helper] ? economic[helper](data, getString) : {};
+
+        return {
+            ...helperData,
+            heading
+        };
+    });
+
+    return <DashboardChartGroup charts={chartsConfig} {...forwardProps} pb={{ sm: 4, xs: 2 }} />;
+};

--- a/src/page-components/GlobalDashboard/GlobalDashboard.tsx
+++ b/src/page-components/GlobalDashboard/GlobalDashboard.tsx
@@ -1,5 +1,6 @@
 import { Communities } from './Communities/Communities';
 import { Distribution } from './Distribution/Distribution';
+import { Economic } from './Economic/Economic';
 import { Fundraising } from './Fundraising/Fundraising';
 import { Global } from './Global/Global';
 import { HealingMap } from './HealingMap/HealingMap';
@@ -21,6 +22,7 @@ export const GlobalDashboard = (props: GlobalDashboardProps) => {
     const communities = page?.communities;
     const distribution = page?.distribution;
     const fundraising = page?.fundraising;
+    const economic = page?.economic;
 
     return (
         <>
@@ -29,6 +31,7 @@ export const GlobalDashboard = (props: GlobalDashboardProps) => {
             <Communities data={data} {...communities} />
             <Distribution data={data} {...distribution} />
             <Fundraising data={data} {...fundraising} />
+            <Economic data={data} {...economic} />
         </>
     );
 };


### PR DESCRIPTION
This PR adds economic chart group to global dashboard page:
<img width="1347" alt="Screenshot 2021-04-01 at 16 51 25" src="https://user-images.githubusercontent.com/7081017/113320727-be80cc00-930a-11eb-8992-82e174880d74.png">
<img width="373" alt="Screenshot 2021-04-01 at 16 51 55" src="https://user-images.githubusercontent.com/7081017/113320730-c04a8f80-930a-11eb-96bc-6bb131da7983.png">
