### PR TITLE
Update Icon component style

### DIFF
--- a/src/theme/components/Icon/Icon.tsx
+++ b/src/theme/components/Icon/Icon.tsx
@@ -14,6 +14,7 @@ type IconProps = {
 };
 
 const IconSvg = styled.svg<GeneratedPropsTypes>`
+    display: inline-block;
     fill: currentColor;
     flex-shrink: 0;
     height: ${({ sHeight }) => (!sHeight ? 'auto' : undefined)};


### PR DESCRIPTION
This PR fixes the display style prop in icons.
Before:
<img width="104" alt="Screenshot 2021-12-28 at 15 19 56" src="https://user-images.githubusercontent.com/7081017/147581016-baee7a41-953e-4a68-b517-f95468e3edbd.png">
After:
<img width="124" alt="Screenshot 2021-12-28 at 15 19 46" src="https://user-images.githubusercontent.com/7081017/147581029-ee514255-ed68-4e78-b95a-6e35b5cd0e88.png">

