### PR TITLE
Add support for error log in dev

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -12,11 +12,6 @@ const config = {
     baseApiUrl: `${process.env.NEXT_PUBLIC_URL_API}/api`!,
 
     /**
-     * Base URL to staging api
-     */
-    stagingApiUrl: `https://impactmarket-api-staging.herokuapp.com`,
-
-    /**
      * cUSD decimals to use in ui format
      */
     cUSDDecimals: 18,

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -78,14 +78,14 @@ export default class Api {
     static async getGlobalNumbers(): Promise<IGlobalNumbers | {}> {
         const response = await getRequest<IGlobalNumbers | undefined>('/global/numbers');
 
-        const data = response?.data;
+        const data = response?.data || ({} as any);
 
         const result = {
-            backers: data?.backers,
-            beneficiaries: Numbers.stringify(+(data?.beneficiaries || 0)),
-            claimed: `$${Numbers.stringify(+(data?.claimed || 0))}`,
-            communities: data?.communities,
-            countries: data?.countries
+            backers: data?.backers || null,
+            beneficiaries: Numbers.stringify(+(data?.beneficiaries || 0)) || null,
+            claimed: `$${Numbers.stringify(+(data?.claimed || 0))}` || null,
+            communities: data?.communities || null,
+            countries: data?.countries || null
         };
 
         return result || {};

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,22 +1,22 @@
 import axios from 'axios';
 import config from '../../config';
 
+const { baseApiUrl: baseURL, isProduction } = config;
+
 let cachedClient: any = null;
 
-const getClient = (forceStaging?: boolean) => {
+const getClient = () => {
     if (cachedClient) {
         return cachedClient;
     }
 
-    cachedClient = axios.create({
-        baseURL: forceStaging ? config.stagingApiUrl : config.baseApiUrl
-    });
+    cachedClient = axios.create({ baseURL });
 
     return cachedClient;
 };
 
-export async function getRequest<T>(endpoint: string, forceStaging: boolean = false): Promise<T | undefined> {
-    const client = getClient(forceStaging);
+export async function getRequest<T>(endpoint: string): Promise<T | undefined> {
+    const client = getClient();
     let response: T | undefined;
 
     try {
@@ -33,7 +33,9 @@ export async function getRequest<T>(endpoint: string, forceStaging: boolean = fa
         }
     } catch (error) {
         // TODO: handle error
-        // console.log(error);
+        if (!isProduction) {
+            console.log(error);
+        }
     }
 
     return response;
@@ -56,7 +58,9 @@ export async function postRequest<T>(endpoint: string, body: object): Promise<T 
         }
     } catch (error) {
         // TODO: handle error
-        // console.log(error);
+        if (!isProduction) {
+            console.log(error);
+        }
     }
 
     return response;


### PR DESCRIPTION
This PR just add the ability for API requests error logging when not in production; also, reverts the hardcoded enforce staging that we had for getting the pending communities and ensures the `getGlobalNumbers` will not return undefined values since this breaks the homepage when the request get's any error.